### PR TITLE
chore: add link to the list of live nodes to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The current configuration will be printed at startup.
 QUBIC_NODES_QUBIC_PEER_LIST:                "5.39.222.64;82.197.173.130;82.197.173.129"
 ```
 
-The list of bootstrap nodes might be found [here](https://app.qubic.li/network/live).
+There is no guarantee that the specified bootstrap peers will be available, and the list is not maintained.
+There are several sources of public peers, for example you can find them [here](https://app.qubic.li/network/live).
 
 #### Optional parameters
 ```shell

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The current configuration will be printed at startup.
 QUBIC_NODES_QUBIC_PEER_LIST:                "5.39.222.64;82.197.173.130;82.197.173.129"
 ```
 
+The list of bootstrap nodes might be found [here](https://app.qubic.li/network/live).
+
 #### Optional parameters
 ```shell
 QUBIC_NODES_QUBIC_EXCHANGE_TIMEOUT:         (default: 2s)


### PR DESCRIPTION
Hey! I faced a stupid issue when all public nodes in example are not available. Decided to contribute a bit to the README to help folks after me. 