### PR TITLE
Add fetching of public peers

### DIFF
--- a/.github/workflows/push-docker-custom.yaml
+++ b/.github/workflows/push-docker-custom.yaml
@@ -3,7 +3,7 @@ name: Deploy dev images to GHCR
 on:
   push:
     branches:
-      - 'feature/configured-nodes-count'
+      - 'feature/public-peers'
 
 jobs:
   push-store-image:
@@ -21,5 +21,5 @@ jobs:
 
       - name: 'Build Inventory Image'
         run: |
-          docker build . --tag ghcr.io/qubic/qubic-nodes:feature-configured-nodes
-          docker push ghcr.io/qubic/qubic-nodes:feature-configured-nodes
+          docker build . --tag ghcr.io/qubic/qubic-nodes:public-peers
+          docker push ghcr.io/qubic/qubic-nodes:public-peers

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ type Configuration struct {
 		ExchangeTimeout       time.Duration `conf:"default:2s"`
 		MaxTickErrorThreshold uint32        `conf:"default:50"`
 		ReliableTickRange     uint32        `conf:"default:30"`
+		UsePublicPeers        bool          `conf:"default:false"`
 	}
 	Service struct {
 		TickerUpdateInterval time.Duration `conf:"default:5s"`
@@ -62,7 +63,7 @@ func run() error {
 	}
 	log.Printf("main: Config :\n%v\n", out)
 
-	container, err := node.NewNodeContainer(config.Qubic.PeerList, config.Qubic.PeerPort, config.Qubic.MaxTickErrorThreshold, config.Qubic.ReliableTickRange, config.Qubic.ExchangeTimeout)
+	container, err := node.NewNodeContainer(config.Qubic.PeerList, config.Qubic.PeerPort, config.Qubic.MaxTickErrorThreshold, config.Qubic.ReliableTickRange, config.Qubic.ExchangeTimeout, config.Qubic.UsePublicPeers)
 	if err != nil {
 		log.Printf("Error: %v\n", err)
 	}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type Configuration struct {
 		PublicPeersCleanInterval time.Duration `conf:"default:24h"`
 	}
 	Service struct {
-		TickerUpdateInterval time.Duration `conf:"default:10s"`
+		TickerUpdateInterval time.Duration `conf:"default:15s"`
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -16,12 +16,14 @@ const prefix = "QUBIC_NODES"
 
 type Configuration struct {
 	Qubic struct {
-		PeerList              []string      `conf:"default:5.39.222.64;82.197.173.130;82.197.173.129"`
-		PeerPort              string        `conf:"default:21841"`
-		ExchangeTimeout       time.Duration `conf:"default:2s"`
-		MaxTickErrorThreshold uint32        `conf:"default:50"`
-		ReliableTickRange     uint32        `conf:"default:30"`
-		UsePublicPeers        bool          `conf:"default:false"`
+		PeerList                 []string      `conf:"default:5.39.222.64;82.197.173.130;82.197.173.129"`
+		PeerPort                 string        `conf:"default:21841"`
+		ExchangeTimeout          time.Duration `conf:"default:2s"`
+		MaxTickErrorThreshold    uint32        `conf:"default:50"`
+		ReliableTickRange        uint32        `conf:"default:30"`
+		UsePublicPeers           bool          `conf:"default:false"`
+		PublicPeersExclude       []string
+		PublicPeersCleanInterval time.Duration `conf:"default:24h"`
 	}
 	Service struct {
 		TickerUpdateInterval time.Duration `conf:"default:10s"`
@@ -103,7 +105,7 @@ func run() error {
 func createPeerDiscoveryStrategy(config Configuration) node.PeerDiscovery {
 	if config.Qubic.UsePublicPeers {
 		log.Println("main: Using public peers")
-		return node.NewPublicPeerDiscovery(config.Qubic.PeerPort, config.Qubic.ExchangeTimeout)
+		return node.NewPublicPeerDiscovery(config.Qubic.PeerPort, config.Qubic.ExchangeTimeout, config.Qubic.PublicPeersExclude, config.Qubic.PublicPeersCleanInterval)
 	} else {
 		log.Println("main: Using static peers")
 		return &node.NoPeerDiscovery{}

--- a/node/peer_discovery.go
+++ b/node/peer_discovery.go
@@ -1,0 +1,1 @@
+package node

--- a/node/peer_discovery.go
+++ b/node/peer_discovery.go
@@ -1,1 +1,108 @@
 package node
+
+import (
+	"log"
+	"slices"
+	"sync"
+	"time"
+)
+
+const maxNewPeers = 100
+
+type PeerDiscovery interface {
+	UpdatePeers(currentNodes []*Node, currentAddresses []string) []*Node
+}
+
+type PublicPeerDiscovery struct {
+	createNodeFunction CreateNode
+	lock               sync.Locker
+}
+
+type PeerList struct {
+	originalPeers []string
+	newPeers      []string
+	mutex         sync.Mutex
+}
+
+func (pl *PeerList) contains(host string) bool {
+	return slices.Contains(pl.originalPeers, host) || slices.Contains(pl.newPeers, host)
+}
+
+func (pl *PeerList) AddIfNew(host string) bool {
+	pl.mutex.Lock()
+	defer pl.mutex.Unlock()
+	if !pl.contains(host) {
+		pl.newPeers = append(pl.newPeers, host)
+		return true
+	} else {
+		return false
+	}
+}
+
+type NoPeerDiscovery struct{}
+
+func (npd NoPeerDiscovery) UpdatePeers(_ []*Node, _ []string) []*Node {
+	return []*Node{}
+}
+
+func NewPublicPeerDiscovery(port string, connectionTimeout time.Duration) *PublicPeerDiscovery {
+	createNodeFunc := func(host string) (*Node, error) {
+		return NewNode(host, port, connectionTimeout)
+	}
+	return newPublicPeerDiscovery(createNodeFunc)
+}
+
+func newPublicPeerDiscovery(createNodeFunc CreateNode) *PublicPeerDiscovery {
+	return &PublicPeerDiscovery{
+		createNodeFunction: createNodeFunc,
+		lock:               &sync.Mutex{},
+	}
+}
+
+func (ppd PublicPeerDiscovery) UpdatePeers(nodes []*Node, addresses []string) []*Node {
+	peerList := &PeerList{
+		originalPeers: addresses,
+		newPeers:      make([]string, 0),
+	}
+
+	var waitGroup sync.WaitGroup
+	nodesChannel := make(chan *Node, maxNewPeers) // TODO move constant
+	for _, node := range nodes {
+		ppd.lookupPeers(node.Peers, peerList, nodesChannel, &waitGroup)
+	}
+	waitGroup.Wait()
+	close(nodesChannel)
+
+	var newNodes []*Node
+	for node := range nodesChannel {
+		newNodes = append(newNodes, node)
+	}
+	if len(newNodes) > 0 {
+		log.Printf("Found [%d] potential new peer(s).", len(newNodes))
+	}
+	return newNodes
+}
+
+// recursive
+func (ppd PublicPeerDiscovery) lookupPeers(hosts []string, peers *PeerList, channel chan *Node, waitGroup *sync.WaitGroup) {
+
+	for _, host := range hosts {
+		// abort if channel is filled with next peer
+		if len(channel) < maxNewPeers-2 && peers.AddIfNew(host) {
+			waitGroup.Add(1)
+			go ppd.lookupPeer(host, peers, channel, waitGroup)
+		}
+	}
+}
+
+// recursive
+func (ppd PublicPeerDiscovery) lookupPeer(host string, peers *PeerList, channel chan *Node, waitGroup *sync.WaitGroup) {
+	defer waitGroup.Done()
+	node, err := ppd.createNodeFunction(host)
+	if err == nil {
+		channel <- node
+		ppd.lookupPeers(node.Peers, peers, channel, waitGroup)
+	} else {
+		log.Printf("Failed to create node: %v\n", err)
+	}
+}

--- a/node/peer_discovery_test.go
+++ b/node/peer_discovery_test.go
@@ -106,16 +106,26 @@ func TestPublicPeerDiscovery_CleanupPeers(t *testing.T) {
 	createNodeFunc := func(host string) (*Node, error) {
 		return nil, nil
 	}
-	discovery := newPublicPeerDiscovery(createNodeFunc, []string{}, time.Nanosecond)
-	time.Sleep(time.Millisecond)
+	discovery := newPublicPeerDiscovery(createNodeFunc, []string{}, 5*time.Millisecond)
+
+	time.Sleep(5 * time.Millisecond)
+	// no clean up as there is no healthy node
 	unhealthy := discovery.CleanupPeers([]*Node{}, []string{"2.3.4.5", "3.4.5.6"})
+	assert.Len(t, unhealthy, 0)
+
+	time.Sleep(5 * time.Millisecond)
+	// clean up both
+	unhealthy = discovery.CleanupPeers([]*Node{createTestNode("1.2.3.4")}, []string{"2.3.4.5", "3.4.5.6"})
 	assert.Len(t, unhealthy, 2)
 	assert.Contains(t, unhealthy, "2.3.4.5")
 	assert.Contains(t, unhealthy, "3.4.5.6")
 
+	time.Sleep(5 * time.Millisecond)
+	// clean up one
 	unhealthy = discovery.CleanupPeers([]*Node{createTestNode("2.3.4.5")}, []string{"2.3.4.5", "3.4.5.6"})
 	assert.Len(t, unhealthy, 1)
 	assert.Contains(t, unhealthy, "3.4.5.6")
+
 }
 
 func getHosts(discoveredPeers []*Node) []string {

--- a/node/peer_discovery_test.go
+++ b/node/peer_discovery_test.go
@@ -9,10 +9,13 @@ import (
 )
 
 func TestNoPeerDiscovery_UpdatePeers(t *testing.T) {
-
 	discovery := NoPeerDiscovery{}
 	assert.Empty(t, discovery.FindNewPeers([]*Node{{}}, []string{"1.2.3.4", "2.3.4.5"}))
+}
 
+func TestNoPeerDiscovery_CleanupPeers(t *testing.T) {
+	discovery := NoPeerDiscovery{}
+	assert.Empty(t, discovery.CleanupPeers([]*Node{}, []string{}))
 }
 
 func TestPeerList_Contains(t *testing.T) {

--- a/node/peer_discovery_test.go
+++ b/node/peer_discovery_test.go
@@ -1,0 +1,60 @@
+package node
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+)
+
+func TestNoPeerDiscovery_UpdatePeers(t *testing.T) {
+
+	discovery := NoPeerDiscovery{}
+	assert.Empty(t, discovery.UpdatePeers([]*Node{{}}, []string{"1.2.3.4", "2.3.4.5"}))
+
+}
+
+func TestPeerList_Contains(t *testing.T) {
+	peerList := PeerList{
+		originalPeers: []string{"1.2.3.4", "2.3.4.5"},
+		newPeers:      []string{"3.4.5.6", "4.5.6.7"},
+		mutex:         sync.Mutex{},
+	}
+
+	assert.True(t, peerList.contains("1.2.3.4"))
+	assert.True(t, peerList.contains("2.3.4.5"))
+	assert.True(t, peerList.contains("3.4.5.6"))
+	assert.True(t, peerList.contains("4.5.6.7"))
+	assert.False(t, peerList.contains("5.6.7.8"))
+}
+
+func TestPeerList_AddIfNew(t *testing.T) {
+	peerList := PeerList{
+		originalPeers: []string{"1.2.3.4", "2.3.4.5"},
+		newPeers:      []string{"3.4.5.6", "4.5.6.7"},
+		mutex:         sync.Mutex{},
+	}
+
+	assert.False(t, peerList.AddIfNew("1.2.3.4"))
+	assert.False(t, peerList.AddIfNew("2.3.4.5"))
+	assert.False(t, peerList.AddIfNew("3.4.5.6"))
+	assert.False(t, peerList.AddIfNew("4.5.6.7"))
+
+	assert.True(t, peerList.AddIfNew("5.6.7.8"))
+	assert.False(t, peerList.AddIfNew("5.6.7.8")) // already added
+}
+
+func TestPublicPeerDiscovery_UpdatePeers(t *testing.T) {
+
+	createNodeFunc := func(host string) (*Node, error) {
+		return createTestNodeWithPeers(host, []string{"1.2.3.4", "5.6.7.8", "6.7.8.9", "7.8.9.0"}), nil // 2 new peers
+	}
+	discovery := newPublicPeerDiscovery(createNodeFunc)
+
+	discoveredPeers := discovery.UpdatePeers([]*Node{
+		createTestNodeWithPeers("1.2.3.4",
+			[]string{"2.3.4.5", "3.4.5.6", "4.5.6.7", "5.6.7.8"}), //  3 new peers
+	}, []string{"1.2.3.4", "2.3.4.5"})
+
+	assert.Len(t, discoveredPeers, 5)
+
+}

--- a/node/peer_discovery_test.go
+++ b/node/peer_discovery_test.go
@@ -1,20 +1,22 @@
 package node
 
 import (
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestNoPeerDiscovery_UpdatePeers(t *testing.T) {
 
 	discovery := NoPeerDiscovery{}
-	assert.Empty(t, discovery.UpdatePeers([]*Node{{}}, []string{"1.2.3.4", "2.3.4.5"}))
+	assert.Empty(t, discovery.FindNewPeers([]*Node{{}}, []string{"1.2.3.4", "2.3.4.5"}))
 
 }
 
 func TestPeerList_Contains(t *testing.T) {
-	peerList := PeerList{
+	peerList := UpdatedPeerList{
 		originalPeers: []string{"1.2.3.4", "2.3.4.5"},
 		newPeers:      []string{"3.4.5.6", "4.5.6.7"},
 		mutex:         sync.Mutex{},
@@ -28,7 +30,7 @@ func TestPeerList_Contains(t *testing.T) {
 }
 
 func TestPeerList_AddIfNew(t *testing.T) {
-	peerList := PeerList{
+	peerList := UpdatedPeerList{
 		originalPeers: []string{"1.2.3.4", "2.3.4.5"},
 		newPeers:      []string{"3.4.5.6", "4.5.6.7"},
 		mutex:         sync.Mutex{},
@@ -44,17 +46,66 @@ func TestPeerList_AddIfNew(t *testing.T) {
 }
 
 func TestPublicPeerDiscovery_UpdatePeers(t *testing.T) {
-
 	createNodeFunc := func(host string) (*Node, error) {
-		return createTestNodeWithPeers(host, []string{"1.2.3.4", "5.6.7.8", "6.7.8.9", "7.8.9.0"}), nil // 2 new peers
+		if host == "6.6.6.6" {
+			return nil, errors.Errorf("Error creating node [%s].", host)
+		} else {
+			// new node with 1 new working peers (6.7.8.9), 1 erroneous new peer (6.6.6.6)
+			return createTestNodeWithPeers(host, []string{"1.2.3.4", "5.6.7.8", "6.6.6.6", "6.7.8.9"}),
+				nil
+		}
 	}
-	discovery := newPublicPeerDiscovery(createNodeFunc)
+	discovery := newPublicPeerDiscovery(createNodeFunc, []string{}, time.Hour)
 
-	discoveredPeers := discovery.UpdatePeers([]*Node{
+	discoveredPeers := discovery.FindNewPeers([]*Node{
 		createTestNodeWithPeers("1.2.3.4",
-			[]string{"2.3.4.5", "3.4.5.6", "4.5.6.7", "5.6.7.8"}), //  3 new peers
+			[]string{"2.3.4.5", "3.4.5.6", "4.5.6.7", "5.6.7.8"}), //  3 new peers ("3.4.5.6", "4.5.6.7", "5.6.7.8")
 	}, []string{"1.2.3.4", "2.3.4.5"})
 
-	assert.Len(t, discoveredPeers, 5)
+	assert.Len(t, discoveredPeers, 4)
 
+	hosts := getHosts(discoveredPeers)
+	assert.Contains(t, hosts, "3.4.5.6")
+	assert.Contains(t, hosts, "4.5.6.7")
+	assert.Contains(t, hosts, "5.6.7.8")
+	assert.Contains(t, hosts, "6.7.8.9")
+}
+
+func TestPublicPeerDiscovery_ExcludePeers(t *testing.T) {
+	createNodeFunc := func(host string) (*Node, error) {
+		return createTestNodeWithPeers(host, []string{"1.2.3.4", "6.6.6.6"}), nil // 6.6.6.6 excluded
+	}
+	discovery := newPublicPeerDiscovery(createNodeFunc, []string{" 6.6.6.6"}, time.Hour)
+
+	discoveredPeers := discovery.FindNewPeers([]*Node{
+		createTestNodeWithPeers("1.2.3.4", []string{"2.3.4.5", "3.4.5.6"}), // 3.4.5.6 new peer
+	}, []string{"1.2.3.4", "2.3.4.5"})
+
+	assert.Len(t, discoveredPeers, 1)
+	hosts := getHosts(discoveredPeers)
+	assert.Contains(t, hosts, "3.4.5.6")
+}
+
+func TestPublicPeerDiscovery_CleanupPeers(t *testing.T) {
+	createNodeFunc := func(host string) (*Node, error) {
+		return nil, nil
+	}
+	discovery := newPublicPeerDiscovery(createNodeFunc, []string{}, time.Nanosecond)
+	time.Sleep(time.Millisecond)
+	unhealthy := discovery.CleanupPeers([]*Node{}, []string{"2.3.4.5", "3.4.5.6"})
+	assert.Len(t, unhealthy, 2)
+	assert.Contains(t, unhealthy, "2.3.4.5")
+	assert.Contains(t, unhealthy, "3.4.5.6")
+
+	unhealthy = discovery.CleanupPeers([]*Node{createTestNode("2.3.4.5")}, []string{"2.3.4.5", "3.4.5.6"})
+	assert.Len(t, unhealthy, 1)
+	assert.Contains(t, unhealthy, "3.4.5.6")
+}
+
+func getHosts(discoveredPeers []*Node) []string {
+	hosts := make([]string, len(discoveredPeers))
+	for _, node := range discoveredPeers {
+		hosts = append(hosts, node.Address)
+	}
+	return hosts
 }

--- a/node/peer_discovery_test.go
+++ b/node/peer_discovery_test.go
@@ -36,13 +36,26 @@ func TestPeerList_AddIfNew(t *testing.T) {
 		mutex:         sync.Mutex{},
 	}
 
-	assert.False(t, peerList.AddIfNew("1.2.3.4"))
-	assert.False(t, peerList.AddIfNew("2.3.4.5"))
-	assert.False(t, peerList.AddIfNew("3.4.5.6"))
-	assert.False(t, peerList.AddIfNew("4.5.6.7"))
+	assert.False(t, peerList.addIfNew("1.2.3.4"))
+	assert.False(t, peerList.addIfNew("2.3.4.5"))
+	assert.False(t, peerList.addIfNew("3.4.5.6"))
+	assert.False(t, peerList.addIfNew("4.5.6.7"))
 
-	assert.True(t, peerList.AddIfNew("5.6.7.8"))
-	assert.False(t, peerList.AddIfNew("5.6.7.8")) // already added
+	assert.True(t, peerList.addIfNew("5.6.7.8"))
+	assert.False(t, peerList.addIfNew("5.6.7.8")) // already added
+}
+
+func TestPeerList_IsAcceptedHost(t *testing.T) {
+
+	peerList := UpdatedPeerList{
+		originalPeers: []string{"1.2.3.4"},
+		newPeers:      []string{"2.3.4.5"},
+		excludedPeers: []string{"6.6.6.6"},
+		mutex:         sync.Mutex{},
+	}
+
+	assert.True(t, peerList.isAcceptedHost("1.2.3.4"))
+	assert.False(t, peerList.isAcceptedHost("6.6.6.6"))
 }
 
 func TestPublicPeerDiscovery_UpdatePeers(t *testing.T) {

--- a/node/peer_discovery_test.go
+++ b/node/peer_discovery_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestNoPeerDiscovery_UpdatePeers(t *testing.T) {
 	discovery := NoPeerDiscovery{}
-	assert.Empty(t, discovery.FindNewPeers([]*Node{{}}, []string{"1.2.3.4", "2.3.4.5"}))
+	assert.Empty(t, discovery.FindNewPeers([]*Node{}, []string{"1.2.3.4", "2.3.4.5"}))
 }
 
 func TestNoPeerDiscovery_CleanupPeers(t *testing.T) {
 	discovery := NoPeerDiscovery{}
-	assert.Empty(t, discovery.CleanupPeers([]*Node{}, []string{}))
+	assert.Empty(t, discovery.CleanupPeers([]*Node{}, []string{"1.2.3.4"}))
 }
 
 func TestPeerList_Contains(t *testing.T) {

--- a/node/peer_manager.go
+++ b/node/peer_manager.go
@@ -1,0 +1,92 @@
+package node
+
+import (
+	"log"
+	"slices"
+	"sync"
+	"time"
+)
+
+type PeerManager struct {
+	configuredPeers    []string
+	currentPeers       []string
+	peerDiscovery      PeerDiscovery
+	createNodeFunction CreateNode
+}
+
+type CreateNode func(host string) (*Node, error)
+
+func NewPeerManager(addresses []string, peerDiscovery PeerDiscovery, port string, connectionTimeout time.Duration) *PeerManager {
+	crateNodeFunc := func(host string) (*Node, error) {
+		return NewNode(host, port, connectionTimeout)
+	}
+	return newPeerManagerWithCreateNodeFunction(addresses, peerDiscovery, crateNodeFunc)
+}
+
+// mainly for testing to inject custom node creation code
+func newPeerManagerWithCreateNodeFunction(addresses []string, peerDiscovery PeerDiscovery, createNodeFunction CreateNode) *PeerManager {
+	peerManager := PeerManager{
+		configuredPeers:    addresses,
+		currentPeers:       addresses,
+		createNodeFunction: createNodeFunction,
+		peerDiscovery:      peerDiscovery,
+	}
+	return &peerManager
+}
+
+func (pm *PeerManager) UpdateNodes() []*Node {
+	onlineNodes := pm.fetchOnlineNodes()
+	go pm.updatePeers(onlineNodes)
+	return onlineNodes
+}
+
+func (pm *PeerManager) fetchOnlineNodes() []*Node {
+
+	var waitGroup sync.WaitGroup
+
+	nodesChannel := make(chan *Node, len(pm.currentPeers))
+	for _, address := range pm.currentPeers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+
+			node, err := pm.createNodeFunction(address)
+			if err != nil {
+				log.Printf("Failed to create node: %v.", err)
+				nodesChannel <- nil
+				return
+			}
+
+			nodesChannel <- node
+		}()
+	}
+
+	waitGroup.Wait()
+	close(nodesChannel)
+
+	var onlineNodes []*Node
+	for node := range nodesChannel {
+		if node != nil {
+			onlineNodes = append(onlineNodes, node)
+		}
+	}
+	return onlineNodes
+}
+
+func (pm *PeerManager) GetNumberOfConfiguredNodes() int {
+	return len(pm.configuredPeers)
+}
+
+func (pm *PeerManager) GetNumberOfKnownNodes() int {
+	return len(pm.currentPeers)
+}
+
+func (pm *PeerManager) updatePeers(nodes []*Node) {
+	newPeers := pm.peerDiscovery.UpdatePeers(nodes, pm.currentPeers)
+	for _, newPeer := range newPeers {
+		if !slices.Contains(pm.currentPeers, newPeer.Address) {
+			log.Printf("Adding peer: [%s].", newPeer.Address)
+			pm.currentPeers = append(pm.currentPeers, newPeer.Address)
+		}
+	}
+}

--- a/node/peer_manager_test.go
+++ b/node/peer_manager_test.go
@@ -1,0 +1,46 @@
+package node
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"testing"
+	"time"
+)
+
+var testTime = time.Now()
+
+func createTestNodes(host string) (*Node, error) {
+	if host == "6.6.6.6" {
+		return nil, errors.New("error creating test node")
+	} else {
+		return createTestNode(host), nil
+	}
+}
+
+func TestPeerManager_UpdateNodes(t *testing.T) {
+	peerDiscovery := NoPeerDiscovery{}
+	peerManager := newPeerManagerWithCreateNodeFunction([]string{"1.2.3.4", "6.6.6.6", "2.3.4.5"}, peerDiscovery, createTestNodes)
+
+	nodes := peerManager.UpdateNodes()
+
+	assert.Len(t, nodes, 2)
+	assert.Contains(t, nodes, createTestNode("1.2.3.4"))
+	assert.Contains(t, nodes, createTestNode("2.3.4.5"))
+}
+
+func createTestNode(host string) *Node {
+	return createTestNodeWithPeers(host, []string{})
+}
+
+func createTestNodeWithPeers(host string, peers []string) *Node {
+	log.Printf("Creating test node [%s]", host)
+	return &Node{
+		Address:           host,
+		Port:              "12345",
+		Peers:             peers,
+		LastTick:          42,
+		LastUpdate:        testTime.UTC().Unix(),
+		LastUpdateSuccess: true,
+	}
+}

--- a/node/peer_manager_test.go
+++ b/node/peer_manager_test.go
@@ -20,7 +20,7 @@ func createTestNodes(host string) (*Node, error) {
 
 func TestPeerManager_UpdateNodes(t *testing.T) {
 	peerDiscovery := NoPeerDiscovery{}
-	peerManager := newPeerManagerWithCreateNodeFunction([]string{"1.2.3.4", "6.6.6.6", "2.3.4.5"}, peerDiscovery, createTestNodes)
+	peerManager := newPeerManagerWithCreateNodeFunction([]string{"1.2.3.4", "6.6.6.6", "2.3.4.5"}, &peerDiscovery, createTestNodes)
 
 	nodes := peerManager.UpdateNodes()
 

--- a/web/handler.go
+++ b/web/handler.go
@@ -76,7 +76,7 @@ func (h *PeersHandler) HandleStatus(w http.ResponseWriter, _ *http.Request) {
 	response := statusResponse{
 		MaxTick:                 containerResponse.MaxTick,
 		LastUpdate:              containerResponse.LastUpdate,
-		NumberOfConfiguredNodes: len(h.Container.Addresses),
+		NumberOfConfiguredNodes: h.Container.GetNumberOfConfiguredNodes(),
 		ReliableNodes:           reliableNodes,
 		MostReliableNode:        mostReliableResponse,
 	}

--- a/web/handler_test.go
+++ b/web/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestHandler_whenStatus_thenReturnNumberOfConfiguredNodes(t *testing.T) {
@@ -34,17 +35,17 @@ func TestHandler_whenStatus_thenReturnNumberOfConfiguredNodes(t *testing.T) {
 		LastUpdateSuccess: true,
 	}
 
-	var container = node.Container{
+	peerManager := node.NewPeerManager([]string{node1.Address, node2.Address}, &node.NoPeerDiscovery{}, "12345", time.Second)
 
-		ConfiguredAddresses: []string{node1.Address, node2.Address},
-		Port:                "12345",
-		TickErrorThreshold:  3,
-		ReliableTickRange:   4,
-		OnlineNodes:         nil,
-		MaxTick:             123,
-		LastUpdate:          1500000000,
-		ReliableNodes:       []*node.Node{&node1},
-		MostReliableNode:    &node1,
+	var container = node.Container{
+		PeerManager:        peerManager,
+		TickErrorThreshold: 3,
+		ReliableTickRange:  4,
+		OnlineNodes:        nil,
+		MaxTick:            123,
+		LastUpdate:         1500000000,
+		ReliableNodes:      []*node.Node{&node1},
+		MostReliableNode:   &node1,
 	}
 
 	handler := PeersHandler{

--- a/web/handler_test.go
+++ b/web/handler_test.go
@@ -36,15 +36,15 @@ func TestHandler_whenStatus_thenReturnNumberOfConfiguredNodes(t *testing.T) {
 
 	var container = node.Container{
 
-		Addresses:          []string{node1.Address, node2.Address},
-		Port:               "12345",
-		TickErrorThreshold: 3,
-		ReliableTickRange:  4,
-		OnlineNodes:        nil,
-		MaxTick:            123,
-		LastUpdate:         1500000000,
-		ReliableNodes:      []*node.Node{&node1},
-		MostReliableNode:   &node1,
+		ConfiguredAddresses: []string{node1.Address, node2.Address},
+		Port:                "12345",
+		TickErrorThreshold:  3,
+		ReliableTickRange:   4,
+		OnlineNodes:         nil,
+		MaxTick:             123,
+		LastUpdate:          1500000000,
+		ReliableNodes:       []*node.Node{&node1},
+		MostReliableNode:    &node1,
 	}
 
 	handler := PeersHandler{


### PR DESCRIPTION
Updated PR

* Refactored code and made it more testable.
* Node fetching is done recursively now.
* Added blacklist so that we do not fetch the peers that are needed somewhere else.

Closes https://github.com/qubic/go-qubic-nodes/issues/18