### PR TITLE
Add fix to peer discovery logic.

### DIFF
--- a/.github/workflows/push-docker-custom.yaml
+++ b/.github/workflows/push-docker-custom.yaml
@@ -3,7 +3,7 @@ name: Deploy dev images to GHCR
 on:
   push:
     branches:
-      - 'feature/public-peers'
+      - 'peer-discovery-issue'
 
 jobs:
   push-store-image:
@@ -21,5 +21,5 @@ jobs:
 
       - name: 'Build Inventory Image'
         run: |
-          docker build . --tag ghcr.io/qubic/qubic-nodes:public-peers
-          docker push ghcr.io/qubic/qubic-nodes:public-peers
+          docker build . --tag ghcr.io/qubic/qubic-nodes:peer-discovery-issue
+          docker push ghcr.io/qubic/qubic-nodes:peer-discovery-issue

--- a/node/peer_discovery.go
+++ b/node/peer_discovery.go
@@ -111,8 +111,10 @@ func (ppd *PublicPeerDiscovery) FindNewPeers(nodes []*Node, addresses []string) 
 	for _, node := range nodes {
 		ppd.lookupPeers(node.Peers, peers, nodesChannel, &waitGroup)
 	}
-	waitGroup.Wait()
-	close(nodesChannel)
+	go func() {
+		waitGroup.Wait()
+		close(nodesChannel)
+	}()
 
 	var newNodes []*Node
 	for node := range nodesChannel {


### PR DESCRIPTION
The FindNewPeers method had a deadlock: the channel was only read after waitGroup.Wait(), but goroutines blocked on sending to the full channel prevented Wait from ever returning. When the recursive peer discovery found more than 50 nodes, the 51st send blocked, leaked the goroutine, and silently prevented any discovered peers from being added. The fix moves waitGroup.Wait() and close() into a separate goroutine so the channel is drained concurrently with discovery, preventing the buffer from filling up.